### PR TITLE
[SYCL-BLAS] Support for SYCL-BLAS lib

### DIFF
--- a/src/tamm/CMakeLists.txt
+++ b/src/tamm/CMakeLists.txt
@@ -24,7 +24,7 @@ if(USE_DPCPP)
 endif()
 
 #Add the current directory's sources to the list
-set(TAMM_SRCS tamm.cpp index_space.cpp execution_context.cpp tensor_base.cpp)
+set(TAMM_SRCS tamm.cpp index_space.cpp execution_context.cpp tensor_base.cpp kernels/cpu_blas.cpp kernels/gpu_blas.cpp)
 
 #Add the current directory's header files to the list
 set(TAMM_INCLUDES
@@ -65,6 +65,7 @@ set(TAMM_INCLUDES
     lru_cache.hpp
     kernels/assign.hpp
     kernels/multiply.hpp
+    kernels/tamm_blas.hpp    
     op_dag.hpp
     interfaces.hpp
     op_profiler.hpp

--- a/src/tamm/blockops_blas.hpp
+++ b/src/tamm/blockops_blas.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
 #include "tamm/block_span.hpp"
-#include "tamm/kernels/multiply.hpp"
+#include "ga/ga_linalg.h"
+//#include "tamm/kernels/multiply.hpp"
 #include "tamm/types.hpp"
 #include "tamm/utils.hpp"
 

--- a/src/tamm/kernels/cpu_blas.cpp
+++ b/src/tamm/kernels/cpu_blas.cpp
@@ -2,15 +2,18 @@
 
 #include "ga/ga_linalg.h"
 
-namespace tamm::kernels {
-namespace cpu {
-
 template<typename T, typename T1, typename T2, typename T3>
-void blas(int m, int n, int k, const T alpha, const T2* A, int lda, const T3* B, int ldb,
+void tamm::kernels::cpu::blas(int m, int n, int k, const T alpha, const T2* A, int lda, const T3* B, int ldb,
           const T beta, T1* C, int ldc) {
   blas::gemm(blas::Layout::RowMajor, blas::Op::NoTrans, blas::Op::NoTrans, m, n, k, alpha, A, lda,
              B, ldb, beta, C, ldc);
 }
 
-} // namespace cpu
-} // namespace tamm::kernels
+// Explicit template instantiations
+template void tamm::kernels::cpu::blas(int m, int n, int k, const double alpha, const double* A, int lda, const double* B, int ldb, const double beta, double* C, int ldc);
+template void tamm::kernels::cpu::blas(int m, int n, int k, const std::complex<double> alpha, const std::complex<double>* A, int lda, const std::complex<double>* B, int ldb, const std::complex<double> beta, std::complex<double>* C, int ldc);
+template void tamm::kernels::cpu::blas(int m, int n, int k, const float alpha, const float* A, int lda, const float* B, int ldb, const float beta, float* C, int ldc);
+template void tamm::kernels::cpu::blas(int m, int n, int k, const std::complex<float> alpha, const std::complex<float>* A, int lda, const std::complex<float>* B, int ldb, const std::complex<float> beta, std::complex<float>* C, int ldc);
+
+// blas::gemm(blas::Layout, blas::Op, blas::Op, long, long, long, double, double const*, long, double const*, long, double, double*, long);
+// blas::gemm(blas::Layout, blas::Op, blas::Op, long, long, long, std::complex<double>, std::complex<double> const*, long, std::complex<double> const*, long, std::complex<double>, std::complex<double>*, long);

--- a/src/tamm/kernels/cpu_blas.cpp
+++ b/src/tamm/kernels/cpu_blas.cpp
@@ -1,0 +1,20 @@
+#include "tamm_blas.hpp"
+
+#include "ga/ga_linalg.h"
+
+namespace tamm::kernels {
+  namespace cpu {
+
+    template<typename T, typename T1, typename T2, typename T3>
+    void blas(int m, int n, int k,
+              const T alpha,
+              const T2 *A, int lda,
+              const T3 *B, int ldb,
+              const T beta,
+              T1 *C, int ldc) {
+      blas::gemm(blas::Layout::RowMajor, blas::Op::NoTrans, blas::Op::NoTrans, m, n, k, alpha,
+                 A, lda, B, ldb, beta, C, ldc);
+    }
+
+  } // namespace cpu
+} // namespace tamm::kernels

--- a/src/tamm/kernels/cpu_blas.cpp
+++ b/src/tamm/kernels/cpu_blas.cpp
@@ -3,18 +3,14 @@
 #include "ga/ga_linalg.h"
 
 namespace tamm::kernels {
-  namespace cpu {
+namespace cpu {
 
-    template<typename T, typename T1, typename T2, typename T3>
-    void blas(int m, int n, int k,
-              const T alpha,
-              const T2 *A, int lda,
-              const T3 *B, int ldb,
-              const T beta,
-              T1 *C, int ldc) {
-      blas::gemm(blas::Layout::RowMajor, blas::Op::NoTrans, blas::Op::NoTrans, m, n, k, alpha,
-                 A, lda, B, ldb, beta, C, ldc);
-    }
+template<typename T, typename T1, typename T2, typename T3>
+void blas(int m, int n, int k, const T alpha, const T2* A, int lda, const T3* B, int ldb,
+          const T beta, T1* C, int ldc) {
+  blas::gemm(blas::Layout::RowMajor, blas::Op::NoTrans, blas::Op::NoTrans, m, n, k, alpha, A, lda,
+             B, ldb, beta, C, ldc);
+}
 
-  } // namespace cpu
+} // namespace cpu
 } // namespace tamm::kernels

--- a/src/tamm/kernels/cpu_blas.cpp
+++ b/src/tamm/kernels/cpu_blas.cpp
@@ -26,8 +26,3 @@ template void tamm::kernels::cpu::blas(int m, int n, int k, const std::complex<f
                                        const std::complex<float>* B, int ldb,
                                        const std::complex<float> beta, std::complex<float>* C,
                                        int ldc);
-
-// blas::gemm(blas::Layout, blas::Op, blas::Op, long, long, long, double, double const*, long,
-// double const*, long, double, double*, long); blas::gemm(blas::Layout, blas::Op, blas::Op, long,
-// long, long, std::complex<double>, std::complex<double> const*, long, std::complex<double> const*,
-// long, std::complex<double>, std::complex<double>*, long);

--- a/src/tamm/kernels/cpu_blas.cpp
+++ b/src/tamm/kernels/cpu_blas.cpp
@@ -3,17 +3,31 @@
 #include "ga/ga_linalg.h"
 
 template<typename T, typename T1, typename T2, typename T3>
-void tamm::kernels::cpu::blas(int m, int n, int k, const T alpha, const T2* A, int lda, const T3* B, int ldb,
-          const T beta, T1* C, int ldc) {
+void tamm::kernels::cpu::blas(int m, int n, int k, const T alpha, const T2* A, int lda, const T3* B,
+                              int ldb, const T beta, T1* C, int ldc) {
   blas::gemm(blas::Layout::RowMajor, blas::Op::NoTrans, blas::Op::NoTrans, m, n, k, alpha, A, lda,
              B, ldb, beta, C, ldc);
 }
 
 // Explicit template instantiations
-template void tamm::kernels::cpu::blas(int m, int n, int k, const double alpha, const double* A, int lda, const double* B, int ldb, const double beta, double* C, int ldc);
-template void tamm::kernels::cpu::blas(int m, int n, int k, const std::complex<double> alpha, const std::complex<double>* A, int lda, const std::complex<double>* B, int ldb, const std::complex<double> beta, std::complex<double>* C, int ldc);
-template void tamm::kernels::cpu::blas(int m, int n, int k, const float alpha, const float* A, int lda, const float* B, int ldb, const float beta, float* C, int ldc);
-template void tamm::kernels::cpu::blas(int m, int n, int k, const std::complex<float> alpha, const std::complex<float>* A, int lda, const std::complex<float>* B, int ldb, const std::complex<float> beta, std::complex<float>* C, int ldc);
+template void tamm::kernels::cpu::blas(int m, int n, int k, const double alpha, const double* A,
+                                       int lda, const double* B, int ldb, const double beta,
+                                       double* C, int ldc);
+template void tamm::kernels::cpu::blas(int m, int n, int k, const std::complex<double> alpha,
+                                       const std::complex<double>* A, int lda,
+                                       const std::complex<double>* B, int ldb,
+                                       const std::complex<double> beta, std::complex<double>* C,
+                                       int ldc);
+template void tamm::kernels::cpu::blas(int m, int n, int k, const float alpha, const float* A,
+                                       int lda, const float* B, int ldb, const float beta, float* C,
+                                       int ldc);
+template void tamm::kernels::cpu::blas(int m, int n, int k, const std::complex<float> alpha,
+                                       const std::complex<float>* A, int lda,
+                                       const std::complex<float>* B, int ldb,
+                                       const std::complex<float> beta, std::complex<float>* C,
+                                       int ldc);
 
-// blas::gemm(blas::Layout, blas::Op, blas::Op, long, long, long, double, double const*, long, double const*, long, double, double*, long);
-// blas::gemm(blas::Layout, blas::Op, blas::Op, long, long, long, std::complex<double>, std::complex<double> const*, long, std::complex<double> const*, long, std::complex<double>, std::complex<double>*, long);
+// blas::gemm(blas::Layout, blas::Op, blas::Op, long, long, long, double, double const*, long,
+// double const*, long, double, double*, long); blas::gemm(blas::Layout, blas::Op, blas::Op, long,
+// long, long, std::complex<double>, std::complex<double> const*, long, std::complex<double> const*,
+// long, std::complex<double>, std::complex<double>*, long);

--- a/src/tamm/kernels/gpu_blas.cpp
+++ b/src/tamm/kernels/gpu_blas.cpp
@@ -1,0 +1,129 @@
+#include "tamm_blas.hpp"
+
+#if defined(USE_CUDA)
+#include <cublas_v2.h>
+#elif defined(USE_HIP)
+#include <rocblas.h>
+#elif defined(USE_DPCPP)
+#include <oneapi/mkl/blas.hpp>
+
+#if defined(USE_SYCL_BLAS)
+#include <sycl_blas.h>
+#endif // USE_SYCL_BLAS
+
+#endif // USE_DPCPP
+
+#if defined(USE_HIP)
+#define ROCBLAS_CHECK(FUNC)                                                                      \
+  do {                                                                                           \
+    rocblas_status err_ = (FUNC);                                                                \
+    if(err_ != rocblas_status_success) {                                                         \
+      std::ostringstream msg;                                                                    \
+      msg << "ROCBLAS Error: " << rocblas_status_to_string(err_) << ", at " << __FILE__ << " : " \
+          << __LINE__ << std::endl;                                                              \
+      throw std::runtime_error(msg.str());                                                       \
+    }                                                                                            \
+  } while(0)
+#endif // USE_HIP
+
+#if defined(USE_CUDA)
+#define CUBLAS_CHECK(FUNC)                                                                   \
+  do {                                                                                       \
+    cublasStatus_t err_ = (FUNC);                                                            \
+    if(err_ != CUBLAS_STATUS_SUCCESS) {                                                      \
+      std::ostringstream msg;                                                                \
+      msg << "CUBLAS Error: " << cublasGetStatusString(err_) << ", at " << __FILE__ << " : " \
+          << __LINE__ << std::endl;                                                          \
+      throw std::runtime_error(msg.str());                                                   \
+    }                                                                                        \
+  } while(0)
+#endif // USE_CUDA
+
+#if defined(USE_DPCPP)
+#define ONEMKLBLAS_CHECK(FUNC)                                                         \
+  do {                                                                                 \
+    try {                                                                              \
+      (FUNC)                                                                           \
+    } catch(oneapi::mkl::exception const& ex) {                                        \
+      std::ostringstream msg;                                                          \
+      msg << "oneMKL Error: " << ex.what() << ", at " << __FILE__ << " : " << __LINE__ \
+          << std::endl;                                                                \
+      throw std::runtime_error(msg.str());                                             \
+    }                                                                                  \
+  } while(0)
+#endif // USE_DPCPP
+
+namespace tamm::kernels {
+  namespace gpu {
+
+    template<typename T, typename T1, typename T2, typename T3>
+    void blas(int m, int n, int k,
+              const T alpha,
+              const T2 *A, int lda,
+              const T3 *B, int ldb,
+              const T beta,
+              T1 *C, int ldc, gpuStream_t& handle) {
+
+#if defined(USE_DPCPP)
+#ifdef USE_SYCL_BLAS
+      auto dgemm = ::_gemm(handle.first, 'n', 'n', n, m, k, alpha,
+                           B, ldb,
+                           A, lda, beta,
+                           C, ldc);
+      dgemm.wait();
+#else
+          try {
+            auto dgemm = oneapi::mkl::blas::column_major::gemm(
+              handle.first, oneapi::mkl::transpose::N, oneapi::mkl::transpose::N, n, m, k, alpha,
+              B, ldb,
+              A, lda, beta,
+              C, ldc);
+            dgemm.wait();
+          } catch(oneapi::mkl::exception const& ex) {
+            std::stringstream msg;
+            msg << "oneMKL Exception at " << __FILE__ << " : " << __LINE__ << std::endl;
+            throw(std::runtime_error(ex.what()));
+          }
+#endif // USE_SYCL_BLAS
+
+#elif defined(USE_CUDA)
+          if constexpr(internal::is_complex_v<T1> && internal::is_complex_v<T2> &&
+                       internal::is_complex_v<T3>) {
+            CUBLAS_CHECK(cublasZgemm(
+              handle.second, CUBLAS_OP_N, CUBLAS_OP_N, n, m, k, (cuDoubleComplex*) &alpha,
+              (cuDoubleComplex*) B, ldb,
+              (cuDoubleComplex*) A, lda,
+              (cuDoubleComplex*) &beta, (cuDoubleComplex*) C,
+              ldc));
+          }
+          else {
+            CUBLAS_CHECK(cublasDgemm(handle.second, CUBLAS_OP_N, CUBLAS_OP_N, n, m, k, &alpha,
+                                     B, ldb,
+                                     A, lda,
+                                     &beta, C, ldc));
+          }
+#elif defined(USE_HIP)
+          if constexpr(internal::is_complex_v<T1> && internal::is_complex_v<T2> &&
+                       internal::is_complex_v<T3>) {
+            ROCBLAS_CHECK(rocblas_zgemm(
+              handle.second, rocblas_operation_none, rocblas_operation_none, n, m, k,
+              (rocblas_double_complex*) &alpha,
+              (rocblas_double_complex*) B,
+              ldb,
+              (rocblas_double_complex*) A,
+              lda, (rocblas_double_complex*) &beta,
+              (rocblas_double_complex*) C, ldc));
+          }
+          else {
+            ROCBLAS_CHECK(
+              rocblas_dgemm(handle.second, rocblas_operation_none, rocblas_operation_none, n, m, k, &alpha,
+                            B, ldb,
+                            A, lda, &beta,
+                            C, ldc));
+          }
+#endif
+
+    }
+
+  } // namespace gpu
+} // namespace tamm::kernels

--- a/src/tamm/kernels/gpu_blas.cpp
+++ b/src/tamm/kernels/gpu_blas.cpp
@@ -53,27 +53,25 @@
   } while(0)
 #endif // USE_DPCPP
 
-typename blas::SB_Handle::event_t _gemm(blas::SB_Handle& sb_handle, char _TransA, char _TransB, int _M, int _N, int _K, double _alpha, double const* a_, int _lda, double const* b_, int _ldb, double _beta, double* _C, int _ldc, const blas::SB_Handle::event_t& _dependencies = {});
-
 template<typename T, typename T1, typename T2, typename T3>
 void tamm::kernels::gpu::blas(int m, int n, int k, const T alpha, const T2* A, int lda, const T3* B, int ldb,
           const T beta, T1* C, int ldc, gpuStream_t& handle) {
 #if defined(USE_DPCPP)
-#ifdef USE_SYCL_BLAS
+// #ifdef USE_SYCL_BLAS
   blas::SB_Handle sb_handle(handle.first);
   blas::_gemm(sb_handle, 'n', 'n', n, m, k, alpha, B, ldb, A, lda, beta, C, ldc, {});
-#else
-  try {
-    auto dgemm = oneapi::mkl::blas::column_major::gemm(handle.first, oneapi::mkl::transpose::N,
-                                                       oneapi::mkl::transpose::N, n, m, k, alpha, B,
-                                                       ldb, A, lda, beta, C, ldc);
-    dgemm.wait();
-  } catch(oneapi::mkl::exception const& ex) {
-    std::stringstream msg;
-    msg << "oneMKL Exception at " << __FILE__ << " : " << __LINE__ << std::endl;
-    throw(std::runtime_error(ex.what()));
-  }
-#endif // USE_SYCL_BLAS
+// #else
+//   try {
+//     auto dgemm = oneapi::mkl::blas::column_major::gemm(handle.first, oneapi::mkl::transpose::N,
+//                                                        oneapi::mkl::transpose::N, n, m, k, alpha, B,
+//                                                        ldb, A, lda, beta, C, ldc);
+//     dgemm.wait();
+//   } catch(oneapi::mkl::exception const& ex) {
+//     std::stringstream msg;
+//     msg << "oneMKL Exception at " << __FILE__ << " : " << __LINE__ << std::endl;
+//     throw(std::runtime_error(ex.what()));
+//   }
+// #endif // USE_SYCL_BLAS
 
 #elif defined(USE_CUDA)
   if constexpr(internal::is_complex_v<T1> && internal::is_complex_v<T2> &&
@@ -104,15 +102,12 @@ void tamm::kernels::gpu::blas(int m, int n, int k, const T alpha, const T2* A, i
 
 
 // Explicit template instantiations
+extern template blas::SB_Handle::event_t blas::internal::_gemm(blas::SB_Handle& sb_handle, char _TransA, char _TransB, int _M, int _N, int _K, double _alpha, double const* a_, int _lda, double const* b_, int _ldb, double _beta, double* _C, int _ldc, const blas::SB_Handle::event_t& _dependencies = {});
+extern template blas::SB_Handle::event_t blas::internal::_gemm(blas::SB_Handle& sb_handle, char _TransA, char _TransB, int _M, int _N, int _K, std::complex<double> _alpha, std::complex<double> const* a_, int _lda, std::complex<double> const* b_, int _ldb, std::complex<double> _beta, std::complex<double>* _C, int _ldc, const blas::SB_Handle::event_t& _dependencies = {});
+extern template blas::SB_Handle::event_t blas::internal::_gemm(blas::SB_Handle& sb_handle, char _TransA, char _TransB, int _M, int _N, int _K, float _alpha, float const* a_, int _lda, float const* b_, int _ldb, float _beta, float* _C, int _ldc, const blas::SB_Handle::event_t& _dependencies = {});
+extern template blas::SB_Handle::event_t blas::internal::_gemm(blas::SB_Handle& sb_handle, char _TransA, char _TransB, int _M, int _N, int _K, std::complex<float> _alpha, std::complex<float> const* a_, int _lda, std::complex<float> const* b_, int _ldb, std::complex<float> _beta, std::complex<float>* _C, int _ldc, const blas::SB_Handle::event_t& _dependencies = {});
+
 template void tamm::kernels::gpu::blas(int m, int n, int k, const double alpha, const double* A, int lda, const double* B, int ldb, const double beta, double* C, int ldc, gpuStream_t& handle);
 template void tamm::kernels::gpu::blas(int m, int n, int k, const std::complex<double> alpha, const std::complex<double>* A, int lda, const std::complex<double>* B, int ldb, const std::complex<double> beta, std::complex<double>* C, int ldc, gpuStream_t& handle);
 template void tamm::kernels::gpu::blas(int m, int n, int k, const float alpha, const float* A, int lda, const float* B, int ldb, const float beta, float* C, int ldc, gpuStream_t& handle);
 template void tamm::kernels::gpu::blas(int m, int n, int k, const std::complex<float> alpha, const std::complex<float>* A, int lda, const std::complex<float>* B, int ldb, const std::complex<float> beta, std::complex<float>* C, int ldc, gpuStream_t& handle);
-// typename blas::SB_Handle::event_t _gemm(
-//     blas::SB_Handle& sb_handle, char _TransA, char _TransB, int _M, int _N,
-//     int _K, double _alpha, double const* a_, int _lda,
-//     double const* b_, int _ldb, double _beta, double* _C,
-//     int _ldc, const typename blas::SB_Handle::event_t& _dependencies = {});
-
-// typename blas::SB_Handle::event_t _gemm(blas::SB_Handle& sb_handle, char _TransA, char _TransB, int _M, int _N, int _K, std::complex<float> _alpha, std::complex<float> const* a_, int _lda, std::complex<float> const* b_, int _ldb, std::complex<float> _beta, std::complex<float>* _C, int _ldc, const blas::SB_Handle::event_t& _dependencies = {});
-// typename blas::SB_Handle::event_t _gemm(blas::SB_Handle& sb_handle, char _TransA, char _TransB, int _M, int _N, int _K, std::complex<double> _alpha, std::complex<double> const* a_, int _lda, std::complex<double> const* b_, int _ldb, std::complex<double> _beta, std::complex<double>* _C, int _ldc, const blas::SB_Handle::event_t& _dependencies = {});

--- a/src/tamm/kernels/gpu_blas.cpp
+++ b/src/tamm/kernels/gpu_blas.cpp
@@ -6,11 +6,9 @@
 #include <rocblas.h>
 #elif defined(USE_DPCPP)
 #include <oneapi/mkl/blas.hpp>
-
-// #if defined(USE_SYCL_BLAS)
+#if defined(USE_SYCL_BLAS)
 #include <sycl_blas.h>
-// #endif // USE_SYCL_BLAS
-
+#endif // USE_SYCL_BLAS
 #endif // USE_DPCPP
 
 #if defined(USE_HIP)
@@ -54,24 +52,26 @@
 #endif // USE_DPCPP
 
 template<typename T, typename T1, typename T2, typename T3>
-void tamm::kernels::gpu::blas(int m, int n, int k, const T alpha, const T2* A, int lda, const T3* B, int ldb,
-          const T beta, T1* C, int ldc, gpuStream_t& handle) {
+void tamm::kernels::gpu::blas(int m, int n, int k, const T alpha, const T2* A, int lda, const T3* B,
+                              int ldb, const T beta, T1* C, int ldc, gpuStream_t& handle) {
 #if defined(USE_DPCPP)
-// #ifdef USE_SYCL_BLAS
+
+#ifdef USE_SYCL_BLAS
   blas::SB_Handle sb_handle(handle.first);
-  auto event = blas::_gemm(sb_handle, 'n', 'n', n, m, k, alpha, B, ldb, A, lda, beta, C, ldc, {});
-// #else
-//   try {
-//     auto dgemm = oneapi::mkl::blas::column_major::gemm(handle.first, oneapi::mkl::transpose::N,
-//                                                        oneapi::mkl::transpose::N, n, m, k, alpha, B,
-//                                                        ldb, A, lda, beta, C, ldc);
-//     dgemm.wait();
-//   } catch(oneapi::mkl::exception const& ex) {
-//     std::stringstream msg;
-//     msg << "oneMKL Exception at " << __FILE__ << " : " << __LINE__ << std::endl;
-//     throw(std::runtime_error(ex.what()));
-//   }
-// #endif // USE_SYCL_BLAS
+  blas::_gemm(sb_handle, 'n', 'n', n, m, k, alpha, const_cast<T3*>(B), ldb, const_cast<T2*>(A), lda,
+              beta, C, ldc, {});
+#else
+  try {
+    auto dgemm = oneapi::mkl::blas::column_major::gemm(handle.first, oneapi::mkl::transpose::N,
+                                                       oneapi::mkl::transpose::N, n, m, k, alpha, B,
+                                                       ldb, A, lda, beta, C, ldc);
+    dgemm.wait();
+  } catch(oneapi::mkl::exception const& ex) {
+    std::stringstream msg;
+    msg << "oneMKL Exception at " << __FILE__ << " : " << __LINE__ << std::endl;
+    throw(std::runtime_error(ex.what()));
+  }
+#endif // USE_SYCL_BLAS
 
 #elif defined(USE_CUDA)
   if constexpr(internal::is_complex_v<T1> && internal::is_complex_v<T2> &&
@@ -100,14 +100,37 @@ void tamm::kernels::gpu::blas(int m, int n, int k, const T alpha, const T2* A, i
 #endif
 }
 
-
 // Explicit template instantiations
-extern template blas::SB_Handle::event_t blas::_gemm(blas::SB_Handle& sb_handle, char _TransA, char _TransB, int _M, int _N, int _K, double _alpha, double const* a_, int _lda, double const* b_, int _ldb, double _beta, double* _C, int _ldc, const blas::SB_Handle::event_t& _dependencies = {});
-extern template blas::SB_Handle::event_t blas::_gemm(blas::SB_Handle& sb_handle, char _TransA, char _TransB, int _M, int _N, int _K, std::complex<double> _alpha, std::complex<double> const* a_, int _lda, std::complex<double> const* b_, int _ldb, std::complex<double> _beta, std::complex<double>* _C, int _ldc, const blas::SB_Handle::event_t& _dependencies = {});
-extern template blas::SB_Handle::event_t blas::_gemm(blas::SB_Handle& sb_handle, char _TransA, char _TransB, int _M, int _N, int _K, float _alpha, float const* a_, int _lda, float const* b_, int _ldb, float _beta, float* _C, int _ldc, const blas::SB_Handle::event_t& _dependencies = {});
-template blas::SB_Handle::event_t blas::_gemm(blas::SB_Handle& sb_handle, char _TransA, char _TransB, int _M, int _N, int _K, std::complex<float> _alpha, std::complex<float> const* a_, int _lda, std::complex<float> const* b_, int _ldb, std::complex<float> _beta, std::complex<float>* _C, int _ldc, const blas::SB_Handle::event_t& _dependencies = {});
+extern template blas::SB_Handle::event_t
+blas::_gemm(blas::SB_Handle& sb_handle, char _TransA, char _TransB, int _M, int _N, int _K,
+            double _alpha, double* a_, int _lda, double* b_, int _ldb, double _beta, double* _C,
+            int _ldc, const blas::SB_Handle::event_t& _dependencies = {});
+extern template blas::SB_Handle::event_t
+blas::_gemm(blas::SB_Handle& sb_handle, char _TransA, char _TransB, int _M, int _N, int _K,
+            float _alpha, float* a_, int _lda, float* b_, int _ldb, float _beta, float* _C,
+            int _ldc, const blas::SB_Handle::event_t& _dependencies = {});
+// extern template blas::SB_Handle::event_t blas::_gemm(blas::SB_Handle& sb_handle, char _TransA,
+// char _TransB, int _M, int _N, int _K, std::complex<double> _alpha, std::complex<double> * a_, int
+// _lda, std::complex<double> * b_, int _ldb, std::complex<double> _beta, std::complex<double>* _C,
+// int _ldc, const blas::SB_Handle::event_t& _dependencies = {}); template blas::SB_Handle::event_t
+// blas::_gemm(blas::SB_Handle& sb_handle, char _TransA, char _TransB, int _M, int _N, int _K,
+// std::complex<float> _alpha, std::complex<float> * a_, int _lda, std::complex<float> * b_, int
+// _ldb, std::complex<float> _beta, std::complex<float>* _C, int _ldc, const
+// blas::SB_Handle::event_t& _dependencies = {});
 
-template void tamm::kernels::gpu::blas(int m, int n, int k, const double alpha, const double* A, int lda, const double* B, int ldb, const double beta, double* C, int ldc, gpuStream_t& handle);
-template void tamm::kernels::gpu::blas(int m, int n, int k, const std::complex<double> alpha, const std::complex<double>* A, int lda, const std::complex<double>* B, int ldb, const std::complex<double> beta, std::complex<double>* C, int ldc, gpuStream_t& handle);
-template void tamm::kernels::gpu::blas(int m, int n, int k, const float alpha, const float* A, int lda, const float* B, int ldb, const float beta, float* C, int ldc, gpuStream_t& handle);
-template void tamm::kernels::gpu::blas(int m, int n, int k, const std::complex<float> alpha, const std::complex<float>* A, int lda, const std::complex<float>* B, int ldb, const std::complex<float> beta, std::complex<float>* C, int ldc, gpuStream_t& handle);
+template void tamm::kernels::gpu::blas(int m, int n, int k, const double alpha, const double* A,
+                                       int lda, const double* B, int ldb, const double beta,
+                                       double* C, int ldc, gpuStream_t& handle);
+template void tamm::kernels::gpu::blas(int m, int n, int k, const std::complex<double> alpha,
+                                       const std::complex<double>* A, int lda,
+                                       const std::complex<double>* B, int ldb,
+                                       const std::complex<double> beta, std::complex<double>* C,
+                                       int ldc, gpuStream_t& handle);
+template void tamm::kernels::gpu::blas(int m, int n, int k, const float alpha, const float* A,
+                                       int lda, const float* B, int ldb, const float beta, float* C,
+                                       int ldc, gpuStream_t& handle);
+template void tamm::kernels::gpu::blas(int m, int n, int k, const std::complex<float> alpha,
+                                       const std::complex<float>* A, int lda,
+                                       const std::complex<float>* B, int ldb,
+                                       const std::complex<float> beta, std::complex<float>* C,
+                                       int ldc, gpuStream_t& handle);

--- a/src/tamm/kernels/gpu_blas.cpp
+++ b/src/tamm/kernels/gpu_blas.cpp
@@ -7,9 +7,9 @@
 #elif defined(USE_DPCPP)
 #include <oneapi/mkl/blas.hpp>
 
-#if defined(USE_SYCL_BLAS)
+// #if defined(USE_SYCL_BLAS)
 #include <sycl_blas.h>
-#endif // USE_SYCL_BLAS
+// #endif // USE_SYCL_BLAS
 
 #endif // USE_DPCPP
 
@@ -53,16 +53,15 @@
   } while(0)
 #endif // USE_DPCPP
 
-namespace tamm::kernels {
-namespace gpu {
+typename blas::SB_Handle::event_t _gemm(blas::SB_Handle& sb_handle, char _TransA, char _TransB, int _M, int _N, int _K, double _alpha, double const* a_, int _lda, double const* b_, int _ldb, double _beta, double* _C, int _ldc, const blas::SB_Handle::event_t& _dependencies = {});
 
 template<typename T, typename T1, typename T2, typename T3>
-void blas(int m, int n, int k, const T alpha, const T2* A, int lda, const T3* B, int ldb,
+void tamm::kernels::gpu::blas(int m, int n, int k, const T alpha, const T2* A, int lda, const T3* B, int ldb,
           const T beta, T1* C, int ldc, gpuStream_t& handle) {
 #if defined(USE_DPCPP)
 #ifdef USE_SYCL_BLAS
-  auto dgemm = ::_gemm(handle.first, 'n', 'n', n, m, k, alpha, B, ldb, A, lda, beta, C, ldc);
-  dgemm.wait();
+  blas::SB_Handle sb_handle(handle.first);
+  blas::_gemm(sb_handle, 'n', 'n', n, m, k, alpha, B, ldb, A, lda, beta, C, ldc, {});
 #else
   try {
     auto dgemm = oneapi::mkl::blas::column_major::gemm(handle.first, oneapi::mkl::transpose::N,
@@ -103,5 +102,17 @@ void blas(int m, int n, int k, const T alpha, const T2* A, int lda, const T3* B,
 #endif
 }
 
-} // namespace gpu
-} // namespace tamm::kernels
+
+// Explicit template instantiations
+template void tamm::kernels::gpu::blas(int m, int n, int k, const double alpha, const double* A, int lda, const double* B, int ldb, const double beta, double* C, int ldc, gpuStream_t& handle);
+template void tamm::kernels::gpu::blas(int m, int n, int k, const std::complex<double> alpha, const std::complex<double>* A, int lda, const std::complex<double>* B, int ldb, const std::complex<double> beta, std::complex<double>* C, int ldc, gpuStream_t& handle);
+template void tamm::kernels::gpu::blas(int m, int n, int k, const float alpha, const float* A, int lda, const float* B, int ldb, const float beta, float* C, int ldc, gpuStream_t& handle);
+template void tamm::kernels::gpu::blas(int m, int n, int k, const std::complex<float> alpha, const std::complex<float>* A, int lda, const std::complex<float>* B, int ldb, const std::complex<float> beta, std::complex<float>* C, int ldc, gpuStream_t& handle);
+// typename blas::SB_Handle::event_t _gemm(
+//     blas::SB_Handle& sb_handle, char _TransA, char _TransB, int _M, int _N,
+//     int _K, double _alpha, double const* a_, int _lda,
+//     double const* b_, int _ldb, double _beta, double* _C,
+//     int _ldc, const typename blas::SB_Handle::event_t& _dependencies = {});
+
+// typename blas::SB_Handle::event_t _gemm(blas::SB_Handle& sb_handle, char _TransA, char _TransB, int _M, int _N, int _K, std::complex<float> _alpha, std::complex<float> const* a_, int _lda, std::complex<float> const* b_, int _ldb, std::complex<float> _beta, std::complex<float>* _C, int _ldc, const blas::SB_Handle::event_t& _dependencies = {});
+// typename blas::SB_Handle::event_t _gemm(blas::SB_Handle& sb_handle, char _TransA, char _TransB, int _M, int _N, int _K, std::complex<double> _alpha, std::complex<double> const* a_, int _lda, std::complex<double> const* b_, int _ldb, std::complex<double> _beta, std::complex<double>* _C, int _ldc, const blas::SB_Handle::event_t& _dependencies = {});

--- a/src/tamm/kernels/gpu_blas.cpp
+++ b/src/tamm/kernels/gpu_blas.cpp
@@ -59,7 +59,7 @@ void tamm::kernels::gpu::blas(int m, int n, int k, const T alpha, const T2* A, i
 #if defined(USE_DPCPP)
 // #ifdef USE_SYCL_BLAS
   blas::SB_Handle sb_handle(handle.first);
-  blas::_gemm(sb_handle, 'n', 'n', n, m, k, alpha, B, ldb, A, lda, beta, C, ldc, {});
+  auto event = blas::_gemm(sb_handle, 'n', 'n', n, m, k, alpha, B, ldb, A, lda, beta, C, ldc, {});
 // #else
 //   try {
 //     auto dgemm = oneapi::mkl::blas::column_major::gemm(handle.first, oneapi::mkl::transpose::N,
@@ -102,10 +102,10 @@ void tamm::kernels::gpu::blas(int m, int n, int k, const T alpha, const T2* A, i
 
 
 // Explicit template instantiations
-extern template blas::SB_Handle::event_t blas::internal::_gemm(blas::SB_Handle& sb_handle, char _TransA, char _TransB, int _M, int _N, int _K, double _alpha, double const* a_, int _lda, double const* b_, int _ldb, double _beta, double* _C, int _ldc, const blas::SB_Handle::event_t& _dependencies = {});
-extern template blas::SB_Handle::event_t blas::internal::_gemm(blas::SB_Handle& sb_handle, char _TransA, char _TransB, int _M, int _N, int _K, std::complex<double> _alpha, std::complex<double> const* a_, int _lda, std::complex<double> const* b_, int _ldb, std::complex<double> _beta, std::complex<double>* _C, int _ldc, const blas::SB_Handle::event_t& _dependencies = {});
-extern template blas::SB_Handle::event_t blas::internal::_gemm(blas::SB_Handle& sb_handle, char _TransA, char _TransB, int _M, int _N, int _K, float _alpha, float const* a_, int _lda, float const* b_, int _ldb, float _beta, float* _C, int _ldc, const blas::SB_Handle::event_t& _dependencies = {});
-extern template blas::SB_Handle::event_t blas::internal::_gemm(blas::SB_Handle& sb_handle, char _TransA, char _TransB, int _M, int _N, int _K, std::complex<float> _alpha, std::complex<float> const* a_, int _lda, std::complex<float> const* b_, int _ldb, std::complex<float> _beta, std::complex<float>* _C, int _ldc, const blas::SB_Handle::event_t& _dependencies = {});
+extern template blas::SB_Handle::event_t blas::_gemm(blas::SB_Handle& sb_handle, char _TransA, char _TransB, int _M, int _N, int _K, double _alpha, double const* a_, int _lda, double const* b_, int _ldb, double _beta, double* _C, int _ldc, const blas::SB_Handle::event_t& _dependencies = {});
+extern template blas::SB_Handle::event_t blas::_gemm(blas::SB_Handle& sb_handle, char _TransA, char _TransB, int _M, int _N, int _K, std::complex<double> _alpha, std::complex<double> const* a_, int _lda, std::complex<double> const* b_, int _ldb, std::complex<double> _beta, std::complex<double>* _C, int _ldc, const blas::SB_Handle::event_t& _dependencies = {});
+extern template blas::SB_Handle::event_t blas::_gemm(blas::SB_Handle& sb_handle, char _TransA, char _TransB, int _M, int _N, int _K, float _alpha, float const* a_, int _lda, float const* b_, int _ldb, float _beta, float* _C, int _ldc, const blas::SB_Handle::event_t& _dependencies = {});
+template blas::SB_Handle::event_t blas::_gemm(blas::SB_Handle& sb_handle, char _TransA, char _TransB, int _M, int _N, int _K, std::complex<float> _alpha, std::complex<float> const* a_, int _lda, std::complex<float> const* b_, int _ldb, std::complex<float> _beta, std::complex<float>* _C, int _ldc, const blas::SB_Handle::event_t& _dependencies = {});
 
 template void tamm::kernels::gpu::blas(int m, int n, int k, const double alpha, const double* A, int lda, const double* B, int ldb, const double beta, double* C, int ldc, gpuStream_t& handle);
 template void tamm::kernels::gpu::blas(int m, int n, int k, const std::complex<double> alpha, const std::complex<double>* A, int lda, const std::complex<double>* B, int ldb, const std::complex<double> beta, std::complex<double>* C, int ldc, gpuStream_t& handle);

--- a/src/tamm/kernels/gpu_blas.cpp
+++ b/src/tamm/kernels/gpu_blas.cpp
@@ -100,7 +100,7 @@ void tamm::kernels::gpu::blas(int m, int n, int k, const T alpha, const T2* A, i
 #endif
 }
 
-// Explicit template instantiations
+// Explicit template instantiations (for SYCL-BLAS APIs, complex-types are not supported yet)
 extern template blas::SB_Handle::event_t
 blas::_gemm(blas::SB_Handle& sb_handle, char _TransA, char _TransB, int _M, int _N, int _K,
             double _alpha, double* a_, int _lda, double* b_, int _ldb, double _beta, double* _C,

--- a/src/tamm/kernels/gpu_blas.cpp
+++ b/src/tamm/kernels/gpu_blas.cpp
@@ -54,76 +54,54 @@
 #endif // USE_DPCPP
 
 namespace tamm::kernels {
-  namespace gpu {
+namespace gpu {
 
-    template<typename T, typename T1, typename T2, typename T3>
-    void blas(int m, int n, int k,
-              const T alpha,
-              const T2 *A, int lda,
-              const T3 *B, int ldb,
-              const T beta,
-              T1 *C, int ldc, gpuStream_t& handle) {
-
+template<typename T, typename T1, typename T2, typename T3>
+void blas(int m, int n, int k, const T alpha, const T2* A, int lda, const T3* B, int ldb,
+          const T beta, T1* C, int ldc, gpuStream_t& handle) {
 #if defined(USE_DPCPP)
 #ifdef USE_SYCL_BLAS
-      auto dgemm = ::_gemm(handle.first, 'n', 'n', n, m, k, alpha,
-                           B, ldb,
-                           A, lda, beta,
-                           C, ldc);
-      dgemm.wait();
+  auto dgemm = ::_gemm(handle.first, 'n', 'n', n, m, k, alpha, B, ldb, A, lda, beta, C, ldc);
+  dgemm.wait();
 #else
-          try {
-            auto dgemm = oneapi::mkl::blas::column_major::gemm(
-              handle.first, oneapi::mkl::transpose::N, oneapi::mkl::transpose::N, n, m, k, alpha,
-              B, ldb,
-              A, lda, beta,
-              C, ldc);
-            dgemm.wait();
-          } catch(oneapi::mkl::exception const& ex) {
-            std::stringstream msg;
-            msg << "oneMKL Exception at " << __FILE__ << " : " << __LINE__ << std::endl;
-            throw(std::runtime_error(ex.what()));
-          }
+  try {
+    auto dgemm = oneapi::mkl::blas::column_major::gemm(handle.first, oneapi::mkl::transpose::N,
+                                                       oneapi::mkl::transpose::N, n, m, k, alpha, B,
+                                                       ldb, A, lda, beta, C, ldc);
+    dgemm.wait();
+  } catch(oneapi::mkl::exception const& ex) {
+    std::stringstream msg;
+    msg << "oneMKL Exception at " << __FILE__ << " : " << __LINE__ << std::endl;
+    throw(std::runtime_error(ex.what()));
+  }
 #endif // USE_SYCL_BLAS
 
 #elif defined(USE_CUDA)
-          if constexpr(internal::is_complex_v<T1> && internal::is_complex_v<T2> &&
-                       internal::is_complex_v<T3>) {
-            CUBLAS_CHECK(cublasZgemm(
-              handle.second, CUBLAS_OP_N, CUBLAS_OP_N, n, m, k, (cuDoubleComplex*) &alpha,
-              (cuDoubleComplex*) B, ldb,
-              (cuDoubleComplex*) A, lda,
-              (cuDoubleComplex*) &beta, (cuDoubleComplex*) C,
-              ldc));
-          }
-          else {
-            CUBLAS_CHECK(cublasDgemm(handle.second, CUBLAS_OP_N, CUBLAS_OP_N, n, m, k, &alpha,
-                                     B, ldb,
-                                     A, lda,
-                                     &beta, C, ldc));
-          }
+  if constexpr(internal::is_complex_v<T1> && internal::is_complex_v<T2> &&
+               internal::is_complex_v<T3>) {
+    CUBLAS_CHECK(cublasZgemm(handle.second, CUBLAS_OP_N, CUBLAS_OP_N, n, m, k,
+                             (cuDoubleComplex*) &alpha, (cuDoubleComplex*) B, ldb,
+                             (cuDoubleComplex*) A, lda, (cuDoubleComplex*) &beta,
+                             (cuDoubleComplex*) C, ldc));
+  }
+  else {
+    CUBLAS_CHECK(cublasDgemm(handle.second, CUBLAS_OP_N, CUBLAS_OP_N, n, m, k, &alpha, B, ldb, A,
+                             lda, &beta, C, ldc));
+  }
 #elif defined(USE_HIP)
-          if constexpr(internal::is_complex_v<T1> && internal::is_complex_v<T2> &&
-                       internal::is_complex_v<T3>) {
-            ROCBLAS_CHECK(rocblas_zgemm(
-              handle.second, rocblas_operation_none, rocblas_operation_none, n, m, k,
-              (rocblas_double_complex*) &alpha,
-              (rocblas_double_complex*) B,
-              ldb,
-              (rocblas_double_complex*) A,
-              lda, (rocblas_double_complex*) &beta,
-              (rocblas_double_complex*) C, ldc));
-          }
-          else {
-            ROCBLAS_CHECK(
-              rocblas_dgemm(handle.second, rocblas_operation_none, rocblas_operation_none, n, m, k, &alpha,
-                            B, ldb,
-                            A, lda, &beta,
-                            C, ldc));
-          }
+  if constexpr(internal::is_complex_v<T1> && internal::is_complex_v<T2> &&
+               internal::is_complex_v<T3>) {
+    ROCBLAS_CHECK(rocblas_zgemm(handle.second, rocblas_operation_none, rocblas_operation_none, n, m,
+                                k, (rocblas_double_complex*) &alpha, (rocblas_double_complex*) B,
+                                ldb, (rocblas_double_complex*) A, lda,
+                                (rocblas_double_complex*) &beta, (rocblas_double_complex*) C, ldc));
+  }
+  else {
+    ROCBLAS_CHECK(rocblas_dgemm(handle.second, rocblas_operation_none, rocblas_operation_none, n, m,
+                                k, &alpha, B, ldb, A, lda, &beta, C, ldc));
+  }
 #endif
+}
 
-    }
-
-  } // namespace gpu
+} // namespace gpu
 } // namespace tamm::kernels

--- a/src/tamm/kernels/multiply.hpp
+++ b/src/tamm/kernels/multiply.hpp
@@ -4,8 +4,8 @@
 #include "tamm/kernels/assign.hpp"
 #include "tamm/types.hpp"
 
-#include <cstring> // for std::memset
 #include <complex>
+#include <cstring> // for std::memset
 #include <numeric>
 #include <vector>
 
@@ -52,18 +52,15 @@ void gemm_wrapper(ExecutionHW hw, gpuStream_t& thandle, int AR, int BR, int B, i
   for(size_t ari = 0; ari < AR; ari++) {
     for(size_t bri = 0; bri < BR; bri++) {
       for(size_t i = 0; i < B; i++) {
-
 #if defined(USE_CUDA) || defined(USE_HIP) || defined(USE_DPCPP)
         if(hw == ExecutionHW::GPU) {
-          gpu::blas(N, M, K, alpha,
-                    binter_buf_dev + bri * breduce_ld + i * bbatch_ld, binter_ld,
+          gpu::blas(N, M, K, alpha, binter_buf_dev + bri * breduce_ld + i * bbatch_ld, binter_ld,
                     ainter_buf_dev + ari * areduce_ld + i * abatch_ld, ainter_ld, beta,
                     cinter_buf_dev + i * cbatch_ld, cinter_ld, thandle);
           continue;
         }
 #endif
-        cpu::blas(M, N, K, alpha,
-                  ainter_buf + ari * areduce_ld + i * abatch_ld, ainter_ld,
+        cpu::blas(M, N, K, alpha, ainter_buf + ari * areduce_ld + i * abatch_ld, ainter_ld,
                   binter_buf + bri * breduce_ld + i * bbatch_ld, binter_ld, beta,
                   cinter_buf + i * cbatch_ld, cinter_ld);
 

--- a/src/tamm/kernels/multiply.hpp
+++ b/src/tamm/kernels/multiply.hpp
@@ -9,7 +9,7 @@
 #include <numeric>
 #include <vector>
 
-#include "ga/ga_linalg.h"
+#include "tamm_blas.hpp"
 
 #if defined(USE_CUDA) || defined(USE_HIP) || defined(USE_DPCPP)
 #include "librett/librett.h"
@@ -40,10 +40,6 @@ void gemm_wrapper(ExecutionHW hw, gpuStream_t& thandle, int AR, int BR, int B, i
                   T alpha, T beta, const T2* ainter_buf, const T2* ainter_buf_dev,
                   const T3* binter_buf, const T3* binter_buf_dev, T1*& cinter_buf,
                   T1*& cinter_buf_dev) {
-#if defined(USE_CUDA) || defined(USE_HIP)
-  auto& handle = tamm::GPUStreamPool::getInstance().getBlasHandle();
-#endif
-
   int ainter_ld  = K;
   int binter_ld  = N;
   int cinter_ld  = N;
@@ -56,71 +52,20 @@ void gemm_wrapper(ExecutionHW hw, gpuStream_t& thandle, int AR, int BR, int B, i
   for(size_t ari = 0; ari < AR; ari++) {
     for(size_t bri = 0; bri < BR; bri++) {
       for(size_t i = 0; i < B; i++) {
-#if defined(USE_DPCPP)
-        if(hw == ExecutionHW::GPU) {
-          try {
-            auto dgemm = oneapi::mkl::blas::column_major::gemm(
-              thandle, oneapi::mkl::transpose::N, oneapi::mkl::transpose::N, N, M, K, alpha,
-              binter_buf_dev + bri * breduce_ld + i * bbatch_ld, binter_ld,
-              ainter_buf_dev + ari * areduce_ld + i * abatch_ld, ainter_ld, beta,
-              cinter_buf_dev + i * cbatch_ld, cinter_ld);
-            dgemm.wait();
-          } catch(oneapi::mkl::exception const& ex) {
-            std::stringstream msg;
-            msg << "oneMKL Exception at " << __FILE__ << " : " << __LINE__ << std::endl;
-            throw(std::runtime_error(ex.what()));
-          }
 
-          continue;
-        }
-#elif defined(USE_CUDA)
+#if defined(USE_CUDA) || defined(USE_HIP) || defined(USE_DPCPP)
         if(hw == ExecutionHW::GPU) {
-          if constexpr(internal::is_complex_v<T1> && internal::is_complex_v<T2> &&
-                       internal::is_complex_v<T3>) {
-            CUBLAS_CHECK(cublasZgemm(
-              handle, CUBLAS_OP_N, CUBLAS_OP_N, N, M, K, (cuDoubleComplex*) &alpha,
-              (cuDoubleComplex*) binter_buf_dev + bri * breduce_ld + i * bbatch_ld, binter_ld,
-              (cuDoubleComplex*) ainter_buf_dev + ari * areduce_ld + i * abatch_ld, ainter_ld,
-              (cuDoubleComplex*) &beta, (cuDoubleComplex*) cinter_buf_dev + i * cbatch_ld,
-              cinter_ld));
-          }
-          else {
-            CUBLAS_CHECK(cublasDgemm(handle, CUBLAS_OP_N, CUBLAS_OP_N, N, M, K, &alpha,
-                                     binter_buf_dev + bri * breduce_ld + i * bbatch_ld, binter_ld,
-                                     ainter_buf_dev + ari * areduce_ld + i * abatch_ld, ainter_ld,
-                                     &beta, cinter_buf_dev + i * cbatch_ld, cinter_ld));
-          }
-          continue;
-        }
-#elif defined(USE_HIP)
-        if(hw == ExecutionHW::GPU) {
-          if constexpr(internal::is_complex_v<T1> && internal::is_complex_v<T2> &&
-                       internal::is_complex_v<T3>) {
-            ROCBLAS_CHECK(rocblas_zgemm(
-              handle, rocblas_operation_none, rocblas_operation_none, N, M, K,
-              (rocblas_double_complex*) &alpha,
-              (rocblas_double_complex*) binter_buf_dev + bri * breduce_ld + i * bbatch_ld,
-              binter_ld,
-              (rocblas_double_complex*) ainter_buf_dev + ari * areduce_ld + i * abatch_ld,
-              ainter_ld, (rocblas_double_complex*) &beta,
-              (rocblas_double_complex*) cinter_buf_dev + i * cbatch_ld, cinter_ld));
-          }
-          else {
-            ROCBLAS_CHECK(
-              rocblas_dgemm(handle, rocblas_operation_none, rocblas_operation_none, N, M, K, &alpha,
-                            binter_buf_dev + bri * breduce_ld + i * bbatch_ld, binter_ld,
-                            ainter_buf_dev + ari * areduce_ld + i * abatch_ld, ainter_ld, &beta,
-                            cinter_buf_dev + i * cbatch_ld, cinter_ld));
-          }
+          gpu::blas(N, M, K, alpha,
+                    binter_buf_dev + bri * breduce_ld + i * bbatch_ld, binter_ld,
+                    ainter_buf_dev + ari * areduce_ld + i * abatch_ld, ainter_ld, beta,
+                    cinter_buf_dev + i * cbatch_ld, cinter_ld, thandle);
           continue;
         }
 #endif
-
-        // CPU only ops
-        blas::gemm(blas::Layout::RowMajor, blas::Op::NoTrans, blas::Op::NoTrans, M, N, K, alpha,
-                   ainter_buf + ari * areduce_ld + i * abatch_ld, ainter_ld,
-                   binter_buf + bri * breduce_ld + i * bbatch_ld, binter_ld, beta,
-                   cinter_buf + i * cbatch_ld, cinter_ld);
+        cpu::blas(M, N, K, alpha,
+                  ainter_buf + ari * areduce_ld + i * abatch_ld, ainter_ld,
+                  binter_buf + bri * breduce_ld + i * bbatch_ld, binter_ld, beta,
+                  cinter_buf + i * cbatch_ld, cinter_ld);
 
       } // for-i
     }   // for-bri
@@ -217,7 +162,7 @@ void assign_gpu(gpuStream_t& thandle, T*& dst, const SizeVec& ddims, const IntLa
   // create plan
   librettHandle plan;
 #if defined(USE_DPCPP)
-  sycl::queue* ptrQueue = &thandle;
+  sycl::queue* ptrQueue = &(thandle.first);
   librettPlan(&plan, ndim, size, perm, sizeof(T), ptrQueue);
 #else
   librettPlan(&plan, ndim, size, perm, sizeof(T), thandle);
@@ -466,8 +411,8 @@ void block_multiply(
         // copy B to complex buffer
         T1* bbuf_complex{nullptr};
         allocate_host_buffers(hw, bbuf_complex, bsize.value());
-        T3* bbuf_comp_ptr = reinterpret_cast<T3*>(bbuf_complex);
-        blas::copy(bsize.value(), bbufp, 1, bbuf_comp_ptr, 2);
+        // T3* bbuf_comp_ptr = reinterpret_cast<T3*>(bbuf_complex);
+        // blas::copy(bsize.value(), bbufp, 1, bbuf_comp_ptr, 2);
 
         T1* bbuf_complex_dev{nullptr};
         allocate_device_buffers(hw, bbuf_complex_dev, bsize.value());
@@ -495,8 +440,8 @@ void block_multiply(
         // T1,T2 (C,A) are real, T3 (B) is complex
         T1* bbuf_real{nullptr};
         allocate_host_buffers(hw, bbuf_real, bsize.value());
-        T1* bbuf_comp_ptr = reinterpret_cast<T1*>(bbufp);
-        blas::copy(bsize.value(), bbuf_comp_ptr, 2, bbuf_real, 1);
+        // T1* bbuf_comp_ptr = reinterpret_cast<T1*>(bbufp);
+        // blas::copy(bsize.value(), bbuf_comp_ptr, 2, bbuf_real, 1);
 
         T1* bbuf_real_dev{nullptr};
         allocate_device_buffers(hw, bbuf_real_dev, bsize.value());
@@ -534,8 +479,8 @@ void block_multiply(
       if constexpr(internal::is_complex_v<T1>) {
         T1* abuf_complex{nullptr};
         allocate_host_buffers(hw, abuf_complex, asize.value());
-        T2* abuf_comp_ptr = reinterpret_cast<T2*>(abuf_complex);
-        blas::copy(asize.value(), abufp, 1, abuf_comp_ptr, 2);
+        // T2* abuf_comp_ptr = reinterpret_cast<T2*>(abuf_complex);
+        // blas::copy(asize.value(), abufp, 1, abuf_comp_ptr, 2);
 
         T1* abuf_complex_dev{nullptr};
         allocate_device_buffers(hw, abuf_complex_dev, asize.value());
@@ -563,9 +508,8 @@ void block_multiply(
         // T1,T3 (C,B) are real, T2 (A) is complex
         T1* abuf_real{nullptr};
         allocate_host_buffers(hw, abuf_real, asize.value());
-
-        T1* abuf_comp_ptr = reinterpret_cast<T1*>(abufp);
-        blas::copy(asize.value(), abuf_comp_ptr, 2, abuf_real, 1);
+        // T1* abuf_comp_ptr = reinterpret_cast<T1*>(abufp);
+        // blas::copy(asize.value(), abuf_comp_ptr, 2, abuf_real, 1);
 
         T1* abuf_real_dev{nullptr};
         allocate_device_buffers(hw, abuf_real_dev, asize.value());
@@ -604,11 +548,10 @@ void block_multiply(
       T1* bbuf_complex{nullptr};
       allocate_host_buffers(hw, abuf_complex, asize.value());
       allocate_host_buffers(hw, bbuf_complex, bsize.value());
-      T2* abuf_comp_ptr = reinterpret_cast<T2*>(abuf_complex);
-      T2* bbuf_comp_ptr = reinterpret_cast<T2*>(bbuf_complex);
-
-      blas::copy(asize.value(), abufp, 1, abuf_comp_ptr, 2);
-      blas::copy(bsize.value(), bbufp, 1, bbuf_comp_ptr, 2);
+      // T2* abuf_comp_ptr = reinterpret_cast<T2*>(abuf_complex);
+      // T2* bbuf_comp_ptr = reinterpret_cast<T2*>(bbuf_complex);
+      // blas::copy(asize.value(), abufp, 1, abuf_comp_ptr, 2);
+      // blas::copy(bsize.value(), bbufp, 1, bbuf_comp_ptr, 2);
 
       T1* abuf_complex_dev{nullptr};
       T1* bbuf_complex_dev{nullptr};

--- a/src/tamm/kernels/tamm_blas.hpp
+++ b/src/tamm/kernels/tamm_blas.hpp
@@ -4,24 +4,16 @@
 
 namespace tamm::kernels {
 
-  namespace cpu {
-    template<typename T, typename T1, typename T2, typename T3>
-    void blas(int m, int n, int k,
-              const T alpha,
-              const T2 *A, int lda,
-              const T3 *B, int ldb,
-              const T beta,
-              T1 *C, int ldc);
-  } // namespace cpu
+namespace cpu {
+template<typename T, typename T1, typename T2, typename T3>
+void blas(int m, int n, int k, const T alpha, const T2* A, int lda, const T3* B, int ldb,
+          const T beta, T1* C, int ldc);
+} // namespace cpu
 
-  namespace gpu {
-    template<typename T, typename T1, typename T2, typename T3>
-    void blas(int m, int n, int k,
-              const T alpha,
-              const T2 *A, int lda,
-              const T3 *B, int ldb,
-              const T beta,
-              T1 *C, int ldc, gpuStream_t& blashandle);
-  } // namespace gpu
+namespace gpu {
+template<typename T, typename T1, typename T2, typename T3>
+void blas(int m, int n, int k, const T alpha, const T2* A, int lda, const T3* B, int ldb,
+          const T beta, T1* C, int ldc, gpuStream_t& blashandle);
+} // namespace gpu
 
 } // namespace tamm::kernels

--- a/src/tamm/kernels/tamm_blas.hpp
+++ b/src/tamm/kernels/tamm_blas.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "tamm/gpu_streams.hpp"
+
+namespace tamm::kernels {
+
+  namespace cpu {
+    template<typename T, typename T1, typename T2, typename T3>
+    void blas(int m, int n, int k,
+              const T alpha,
+              const T2 *A, int lda,
+              const T3 *B, int ldb,
+              const T beta,
+              T1 *C, int ldc);
+  } // namespace cpu
+
+  namespace gpu {
+    template<typename T, typename T1, typename T2, typename T3>
+    void blas(int m, int n, int k,
+              const T alpha,
+              const T2 *A, int lda,
+              const T3 *B, int ldb,
+              const T beta,
+              T1 *C, int ldc, gpuStream_t& blashandle);
+  } // namespace gpu
+
+} // namespace tamm::kernels

--- a/src/tamm/mr/gpu_memory_resource.hpp
+++ b/src/tamm/mr/gpu_memory_resource.hpp
@@ -36,7 +36,7 @@ private:
 #elif defined(USE_HIP)
     hipMalloc(&ptr, bytes);
 #elif defined(USE_DPCPP)
-    ptr = sycl::malloc_device(bytes, GPUStreamPool::getInstance().getStream());
+    ptr = sycl::malloc_device(bytes, GPUStreamPool::getInstance().getStream().first);
 #endif
 
     return ptr;
@@ -55,7 +55,7 @@ private:
 #elif defined(USE_HIP)
     hipFree(ptr);
 #elif defined(USE_DPCPP)
-    sycl::free(ptr, GPUStreamPool::getInstance().getStream());
+    sycl::free(ptr, GPUStreamPool::getInstance().getStream().first);
 #endif
   }
 

--- a/src/tamm/mr/pinned_memory_resource.hpp
+++ b/src/tamm/mr/pinned_memory_resource.hpp
@@ -70,7 +70,7 @@ class pinned_memory_resource final : public host_memory_resource {
       auto status = hipMallocHost(&ptr, size);
       if (hipSuccess != status) { throw std::bad_alloc{}; }
 #elif defined(USE_DPCPP)
-      ptr = sycl::malloc_host(size, GPUStreamPool::getInstance().getStream());
+      ptr = sycl::malloc_host(size, GPUStreamPool::getInstance().getStream().first);
       if (ptr == nullptr) { throw std::bad_alloc{}; }
 #endif
       return ptr;
@@ -104,7 +104,7 @@ class pinned_memory_resource final : public host_memory_resource {
 #elif defined(USE_HIP)
         hipFreeHost(ptr);
 #elif defined(USE_DPCPP)
-        sycl::free(ptr, GPUStreamPool::getInstance().getStream());
+        sycl::free(ptr, GPUStreamPool::getInstance().getStream().first);
 #endif
       });
   }


### PR DESCRIPTION
Assumes the SYCL-BLAS is installed and path to include, libraries are set via CMake options. 

Also one more important change is that `gpuStream_t` is now mapped to a std::pair<gpuStream_t, gpuBlasHandle_t>`. This is a functional change. 